### PR TITLE
feat: add bl project list command

### DIFF
--- a/.cspell/dicts/project.txt
+++ b/.cspell/dicts/project.txt
@@ -17,3 +17,4 @@ coreutils
 elif
 msvc
 USERPROFILE
+subtasking

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -202,6 +202,22 @@ Updated: (not set)
 (no notification set)
 ```
 
+### `bl project list`
+
+List all projects you have access to.
+
+```bash
+bl project list
+bl project list --json
+```
+
+Example output:
+
+```text
+[TEST] Test Project
+[PROD] Production [archived]
+```
+
 ## Command coverage
 
 The table below maps Backlog API v2 endpoints to `bl` commands.
@@ -220,7 +236,7 @@ Commands that target a specific project accept a `--project <key>` flag.
 
 | Command | API endpoint | Status |
 | --- | --- | --- |
-| `bl project list` | `GET /api/v2/projects` | Planned |
+| `bl project list` | `GET /api/v2/projects` | ✅ Implemented |
 | `bl project show <key>` | `GET /api/v2/projects/{projectIdOrKey}` | Planned |
 | `bl project activities <key>` | `GET /api/v2/projects/{projectIdOrKey}/activities` | Planned |
 | `bl project disk-usage <key>` | `GET /api/v2/projects/{projectIdOrKey}/diskUsage` | Planned |

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -3,12 +3,14 @@ use reqwest::blocking::Client;
 
 pub mod activity;
 pub mod disk_usage;
+pub mod project;
 pub mod space;
 pub mod space_notification;
 pub mod user;
 
 use activity::Activity;
 use disk_usage::DiskUsage;
+use project::Project;
 use space::Space;
 use space_notification::SpaceNotification;
 use user::User;
@@ -19,6 +21,7 @@ pub trait BacklogApi {
     fn get_space_activities(&self) -> Result<Vec<Activity>>;
     fn get_space_disk_usage(&self) -> Result<DiskUsage>;
     fn get_space_notification(&self) -> Result<SpaceNotification>;
+    fn get_projects(&self) -> Result<Vec<Project>>;
 }
 
 impl BacklogApi for BacklogClient {
@@ -40,6 +43,10 @@ impl BacklogApi for BacklogClient {
 
     fn get_space_notification(&self) -> Result<SpaceNotification> {
         self.get_space_notification()
+    }
+
+    fn get_projects(&self) -> Result<Vec<Project>> {
+        self.get_projects()
     }
 }
 

--- a/src/api/project.rs
+++ b/src/api/project.rs
@@ -1,0 +1,84 @@
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+use super::BacklogClient;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Project {
+    pub id: u64,
+    pub project_key: String,
+    pub name: String,
+    pub chart_enabled: bool,
+    pub subtasking_enabled: bool,
+    pub project_leader_can_edit_project_leader: bool,
+    pub text_formatting_rule: String,
+    pub archived: bool,
+    #[serde(flatten)]
+    pub extra: BTreeMap<String, serde_json::Value>,
+}
+
+impl BacklogClient {
+    pub fn get_projects(&self) -> Result<Vec<Project>> {
+        let value = self.get("/projects")?;
+        serde_json::from_value(value.clone()).map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to deserialize projects response: {}\nRaw JSON:\n{}",
+                e,
+                serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string())
+            )
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use httpmock::prelude::*;
+    use serde_json::json;
+
+    fn project_json() -> serde_json::Value {
+        json!({
+            "id": 1,
+            "projectKey": "TEST",
+            "name": "Test Project",
+            "chartEnabled": false,
+            "subtaskingEnabled": false,
+            "projectLeaderCanEditProjectLeader": false,
+            "textFormattingRule": "markdown",
+            "archived": false
+        })
+    }
+
+    #[test]
+    fn get_projects_returns_parsed_list() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(GET).path("/projects");
+            then.status(200).json_body(json!([project_json()]));
+        });
+
+        let client = BacklogClient::new_with(&server.base_url(), "test-key").unwrap();
+        let projects = client.get_projects().unwrap();
+        assert_eq!(projects.len(), 1);
+        assert_eq!(projects[0].id, 1);
+        assert_eq!(projects[0].project_key, "TEST");
+        assert_eq!(projects[0].name, "Test Project");
+        assert!(!projects[0].archived);
+    }
+
+    #[test]
+    fn get_projects_returns_error_on_api_failure() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(GET).path("/projects");
+            then.status(401)
+                .json_body(json!({"errors": [{"message": "Authentication failure"}]}));
+        });
+
+        let client = BacklogClient::new_with(&server.base_url(), "test-key").unwrap();
+        let err = client.get_projects().unwrap_err();
+        assert!(err.to_string().contains("Authentication failure"));
+    }
+}

--- a/src/cmd/auth.rs
+++ b/src/cmd/auth.rs
@@ -176,6 +176,10 @@ mod tests {
         ) -> anyhow::Result<crate::api::space_notification::SpaceNotification> {
             unimplemented!()
         }
+
+        fn get_projects(&self) -> anyhow::Result<Vec<crate::api::project::Project>> {
+            unimplemented!()
+        }
     }
 
     fn sample_user() -> User {

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,2 +1,3 @@
 pub mod auth;
+pub mod project;
 pub mod space;

--- a/src/cmd/project.rs
+++ b/src/cmd/project.rs
@@ -1,0 +1,127 @@
+use anyhow::{Context, Result};
+
+use crate::api::{BacklogApi, BacklogClient, project::Project};
+
+pub fn list(json: bool) -> Result<()> {
+    let client = BacklogClient::from_config()?;
+    list_with(json, &client)
+}
+
+pub fn list_with(json: bool, api: &dyn BacklogApi) -> Result<()> {
+    let projects = api.get_projects()?;
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&projects).context("Failed to serialize JSON")?
+        );
+    } else {
+        for p in &projects {
+            println!("{}", format_project_text(p));
+        }
+    }
+    Ok(())
+}
+
+fn format_project_text(p: &Project) -> String {
+    let archived = if p.archived { " [archived]" } else { "" };
+    format!("[{}] {}{}", p.project_key, p.name, archived)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::{
+        activity::Activity, disk_usage::DiskUsage, project::Project, space::Space,
+        space_notification::SpaceNotification, user::User,
+    };
+    use anyhow::anyhow;
+    use std::collections::BTreeMap;
+
+    struct MockApi {
+        projects: Option<Vec<Project>>,
+    }
+
+    impl BacklogApi for MockApi {
+        fn get_space(&self) -> anyhow::Result<Space> {
+            unimplemented!()
+        }
+
+        fn get_myself(&self) -> anyhow::Result<User> {
+            unimplemented!()
+        }
+
+        fn get_space_activities(&self) -> anyhow::Result<Vec<Activity>> {
+            unimplemented!()
+        }
+
+        fn get_space_disk_usage(&self) -> anyhow::Result<DiskUsage> {
+            unimplemented!()
+        }
+
+        fn get_space_notification(&self) -> anyhow::Result<SpaceNotification> {
+            unimplemented!()
+        }
+
+        fn get_projects(&self) -> anyhow::Result<Vec<Project>> {
+            self.projects.clone().ok_or_else(|| anyhow!("no projects"))
+        }
+    }
+
+    fn sample_project() -> Project {
+        Project {
+            id: 1,
+            project_key: "TEST".to_string(),
+            name: "Test Project".to_string(),
+            chart_enabled: false,
+            subtasking_enabled: false,
+            project_leader_can_edit_project_leader: false,
+            text_formatting_rule: "markdown".to_string(),
+            archived: false,
+            extra: BTreeMap::new(),
+        }
+    }
+
+    fn sample_archived_project() -> Project {
+        Project {
+            archived: true,
+            ..sample_project()
+        }
+    }
+
+    #[test]
+    fn list_with_text_output_succeeds() {
+        let api = MockApi {
+            projects: Some(vec![sample_project()]),
+        };
+        assert!(list_with(false, &api).is_ok());
+    }
+
+    #[test]
+    fn list_with_json_output_succeeds() {
+        let api = MockApi {
+            projects: Some(vec![sample_project()]),
+        };
+        assert!(list_with(true, &api).is_ok());
+    }
+
+    #[test]
+    fn list_with_propagates_api_error() {
+        let api = MockApi { projects: None };
+        let err = list_with(false, &api).unwrap_err();
+        assert!(err.to_string().contains("no projects"));
+    }
+
+    #[test]
+    fn format_project_text_active() {
+        let text = format_project_text(&sample_project());
+        assert!(text.contains("[TEST]"));
+        assert!(text.contains("Test Project"));
+        assert!(!text.contains("[archived]"));
+    }
+
+    #[test]
+    fn format_project_text_archived() {
+        let text = format_project_text(&sample_archived_project());
+        assert!(text.contains("[archived]"));
+    }
+}

--- a/src/cmd/space.rs
+++ b/src/cmd/space.rs
@@ -168,6 +168,10 @@ mod tests {
                 .clone()
                 .ok_or_else(|| anyhow!("no notification"))
         }
+
+        fn get_projects(&self) -> Result<Vec<crate::api::project::Project>> {
+            unimplemented!()
+        }
     }
 
     fn sample_space() -> Space {

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,11 @@ enum Commands {
         #[arg(long)]
         json: bool,
     },
+    /// Manage projects
+    Project {
+        #[command(subcommand)]
+        action: ProjectCommands,
+    },
 }
 
 #[derive(Subcommand)]
@@ -46,6 +51,16 @@ enum SpaceCommands {
     },
     /// Show space notification
     Notification {
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+#[derive(Subcommand)]
+enum ProjectCommands {
+    /// List projects
+    List {
         /// Output as JSON
         #[arg(long)]
         json: bool,
@@ -76,6 +91,9 @@ fn main() -> Result<()> {
             AuthCommands::Status { json } => cmd::auth::status(json),
             AuthCommands::Logout => cmd::auth::logout(),
             AuthCommands::Keyring => cmd::auth::check_keyring(),
+        },
+        Commands::Project { action } => match action {
+            ProjectCommands::List { json } => cmd::project::list(json),
         },
         Commands::Space { action, json } => match action {
             None => cmd::space::show(json),


### PR DESCRIPTION
## Checklist

- [x] Target branch is \`main\`
- [x] Status checks are passing

## Summary

- Implements \`bl project list\` (`GET /api/v2/projects`)
- Supports \`--json\` flag for raw JSON output
- Archived projects are shown with an \`[archived]\` suffix in text mode

## Reason for change

First step in adding project-level commands. Closes the first Planned entry in the command coverage table.

## Changes

- \`src/api/project.rs\` — \`Project\` struct + \`get_projects()\\ with httpmock tests
- \`src/api/mod.rs\` — module registration, trait method, impl
- \`src/cmd/project.rs\` — \`list\` / \`list_with\` functions + formatter + unit tests
- \`src/cmd/mod.rs\` — expose \`project\` module
- \`src/main.rs\` — \`Project\` top-level command with \`list\` subcommand
- \`src/cmd/space.rs\`, \`src/cmd/auth.rs\` — add \`get_projects\` stub to test MockApi
- \`docs/user-guide.md\` — usage section + mark as Implemented in coverage table
- \`.cspell/dicts/project.txt\` — add \`subtasking\` to spell-check dictionary