### PR TITLE
refactor: restore try_new pattern for WikiUpdateArgs and revise AGENTS.md validation rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,9 +94,13 @@ Commands are organized as directories (`src/cmd/<resource>/`) with one file per 
 Validation is split by responsibility:
 
 - **`main.rs` (clap)** — Syntactic/type-level checks only (e.g. "cannot parse as u64").
-- **`cmd/*_with`** — Domain rules and API-spec constraints (e.g. `count <= 100` is a
-  Backlog API limit, not a CLI concern). Place these here so that API spec changes
-  never require touching `main.rs`.
+- **`Args::try_new`** — Domain invariants that must hold before any logic runs
+  (e.g. "at least one of --name or --content must be specified", `count <= 100`).
+  Use a fallible constructor `try_new(...) -> Result<Self>` so errors propagate
+  naturally to `main` via `?`. Do **not** duplicate these checks in `*_with`.
+- **`cmd/*_with`** — API call logic and output formatting only. No validation that
+  belongs in `try_new`. Place API-spec constraints (e.g. field limits) here only
+  when they cannot be known at construction time.
 - **`api/`** — HTTP-level error translation only.
 
 ### Build, lint, and test

--- a/src/cmd/wiki/update.rs
+++ b/src/cmd/wiki/update.rs
@@ -14,20 +14,25 @@ pub struct WikiUpdateArgs {
 }
 
 impl WikiUpdateArgs {
-    pub fn new(
+    pub fn try_new(
         wiki_id: u64,
         name: Option<String>,
         content: Option<String>,
         mail_notify: bool,
         json: bool,
-    ) -> Self {
-        Self {
+    ) -> Result<Self> {
+        if name.is_none() && content.is_none() {
+            return Err(anyhow::anyhow!(
+                "at least one of --name or --content must be specified"
+            ));
+        }
+        Ok(Self {
             wiki_id,
             name,
             content,
             mail_notify,
             json,
-        }
+        })
     }
 }
 
@@ -37,11 +42,6 @@ pub fn update(args: &WikiUpdateArgs) -> Result<()> {
 }
 
 pub fn update_with(args: &WikiUpdateArgs, api: &dyn BacklogApi) -> Result<()> {
-    if args.name.is_none() && args.content.is_none() {
-        return Err(anyhow::anyhow!(
-            "at least one of --name or --content must be specified"
-        ));
-    }
     let mut params: Vec<(String, String)> = Vec::new();
     if let Some(name) = &args.name {
         params.push(("name".to_string(), name.clone()));
@@ -246,7 +246,7 @@ mod tests {
     }
 
     fn args(json: bool) -> WikiUpdateArgs {
-        WikiUpdateArgs::new(1, Some("Updated".to_string()), None, false, json)
+        WikiUpdateArgs::try_new(1, Some("Updated".to_string()), None, false, json).unwrap()
     }
 
     #[test]
@@ -274,9 +274,7 @@ mod tests {
 
     #[test]
     fn update_rejects_no_fields() {
-        let api = MockApi { wiki: None };
-        let args = WikiUpdateArgs::new(1, None, None, false, false);
-        let err = update_with(&args, &api).unwrap_err();
+        let err = WikiUpdateArgs::try_new(1, None, None, false, false).unwrap_err();
         assert!(
             err.to_string()
                 .contains("at least one of --name or --content")

--- a/src/main.rs
+++ b/src/main.rs
@@ -741,13 +741,13 @@ fn run() -> Result<()> {
                 content,
                 mail_notify,
                 json,
-            } => cmd::wiki::update(&WikiUpdateArgs::new(
+            } => cmd::wiki::update(&WikiUpdateArgs::try_new(
                 wiki_id,
                 name,
                 content,
                 mail_notify,
                 json,
-            )),
+            )?),
             WikiCommands::Delete {
                 wiki_id,
                 mail_notify,


### PR DESCRIPTION
## Checklist

- [x] Target branch is `main`
- [x] Status checks are passing

## Summary

- Restore `WikiUpdateArgs::try_new` (was changed to infallible `new` during PR #17 review)
- Remove the duplicated validation from `update_with`; it now lives solely in the constructor
- Update `AGENTS.md` validation boundary rules to explicitly document `Args::try_new` as the preferred place for domain invariants

## Reason for change

PR #17 moved the "at least one of --name or --content" check from the constructor into `update_with` following a Copilot suggestion. However, this conflicts with the existing convention used by `IssueListArgs` and `IssueUpdateArgs` (both use `try_new`), and more importantly, constructor-level validation ensures errors propagate naturally to `main` via `?`.

## Changes

- `AGENTS.md`: add `Args::try_new` layer to the validation boundary section
- `src/cmd/wiki/update.rs`: revert to `try_new` with validation in constructor; remove check from `update_with`; fix tests accordingly
- `src/main.rs`: call `WikiUpdateArgs::try_new(...)?` instead of `WikiUpdateArgs::new(...)`

## Notes

CodeRabbit suggested reverting this change again, but that contradicts the explicit project convention.