### PR TITLE
feat: bl project issue-type add / update / delete

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -130,6 +130,30 @@ pub trait BacklogApi {
     fn get_project_issue_types(&self, _key: &str) -> Result<Vec<ProjectIssueType>> {
         unimplemented!()
     }
+    fn add_project_issue_type(
+        &self,
+        _key: &str,
+        _name: &str,
+        _color: &str,
+    ) -> Result<ProjectIssueType> {
+        unimplemented!()
+    }
+    fn update_project_issue_type(
+        &self,
+        _key: &str,
+        _issue_type_id: u64,
+        _params: &[(String, String)],
+    ) -> Result<ProjectIssueType> {
+        unimplemented!()
+    }
+    fn delete_project_issue_type(
+        &self,
+        _key: &str,
+        _issue_type_id: u64,
+        _substitute_issue_type_id: u64,
+    ) -> Result<ProjectIssueType> {
+        unimplemented!()
+    }
     fn get_project_categories(&self, _key: &str) -> Result<Vec<ProjectCategory>> {
         unimplemented!()
     }
@@ -456,6 +480,33 @@ impl BacklogApi for BacklogClient {
 
     fn get_project_issue_types(&self, key: &str) -> Result<Vec<ProjectIssueType>> {
         self.get_project_issue_types(key)
+    }
+
+    fn add_project_issue_type(
+        &self,
+        key: &str,
+        name: &str,
+        color: &str,
+    ) -> Result<ProjectIssueType> {
+        self.add_project_issue_type(key, name, color)
+    }
+
+    fn update_project_issue_type(
+        &self,
+        key: &str,
+        issue_type_id: u64,
+        params: &[(String, String)],
+    ) -> Result<ProjectIssueType> {
+        self.update_project_issue_type(key, issue_type_id, params)
+    }
+
+    fn delete_project_issue_type(
+        &self,
+        key: &str,
+        issue_type_id: u64,
+        substitute_issue_type_id: u64,
+    ) -> Result<ProjectIssueType> {
+        self.delete_project_issue_type(key, issue_type_id, substitute_issue_type_id)
     }
 
     fn get_project_categories(&self, key: &str) -> Result<Vec<ProjectCategory>> {

--- a/src/api/project.rs
+++ b/src/api/project.rs
@@ -173,6 +173,68 @@ impl BacklogClient {
         })
     }
 
+    pub fn add_project_issue_type(
+        &self,
+        key: &str,
+        name: &str,
+        color: &str,
+    ) -> Result<ProjectIssueType> {
+        let params = vec![
+            ("name".to_string(), name.to_string()),
+            ("color".to_string(), color.to_string()),
+        ];
+        let value = self.post_form(&format!("/projects/{}/issueTypes", key), &params)?;
+        serde_json::from_value(value.clone()).map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to deserialize add project issue type response: {}\nRaw JSON:\n{}",
+                e,
+                serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string())
+            )
+        })
+    }
+
+    pub fn update_project_issue_type(
+        &self,
+        key: &str,
+        issue_type_id: u64,
+        params: &[(String, String)],
+    ) -> Result<ProjectIssueType> {
+        let value = self.patch_form(
+            &format!("/projects/{}/issueTypes/{}", key, issue_type_id),
+            params,
+        )?;
+        serde_json::from_value(value.clone()).map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to deserialize update project issue type response: {}\nRaw JSON:\n{}",
+                e,
+                serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string())
+            )
+        })
+    }
+
+    pub fn delete_project_issue_type(
+        &self,
+        key: &str,
+        issue_type_id: u64,
+        substitute_issue_type_id: u64,
+    ) -> Result<ProjectIssueType> {
+        let params = vec![(
+            "substituteIssueTypeId".to_string(),
+            substitute_issue_type_id.to_string(),
+        )];
+        let value = self.delete_form(
+            &format!("/projects/{}/issueTypes/{}", key, issue_type_id),
+            &params,
+        )?;
+        serde_json::from_value(value.clone()).map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to deserialize delete project issue type response: {}\nRaw JSON:\n{}",
+                e,
+                serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string())
+            )
+        })
+    }
+
     pub fn get_project_categories(&self, key: &str) -> Result<Vec<ProjectCategory>> {
         let value = self.get(&format!("/projects/{}/categories", key))?;
         serde_json::from_value(value.clone()).map_err(|e| {

--- a/src/cmd/project/issue_type.rs
+++ b/src/cmd/project/issue_type.rs
@@ -14,6 +14,90 @@ impl ProjectIssueTypeListArgs {
     }
 }
 
+#[cfg_attr(test, derive(Debug))]
+pub struct ProjectIssueTypeAddArgs {
+    key: String,
+    name: String,
+    color: String,
+    json: bool,
+}
+
+impl ProjectIssueTypeAddArgs {
+    pub fn try_new(key: String, name: String, color: String, json: bool) -> anyhow::Result<Self> {
+        validate_color(&color)?;
+        Ok(Self {
+            key,
+            name,
+            color,
+            json,
+        })
+    }
+}
+
+#[cfg_attr(test, derive(Debug))]
+pub struct ProjectIssueTypeUpdateArgs {
+    key: String,
+    issue_type_id: u64,
+    name: Option<String>,
+    color: Option<String>,
+    json: bool,
+}
+
+impl ProjectIssueTypeUpdateArgs {
+    pub fn try_new(
+        key: String,
+        issue_type_id: u64,
+        name: Option<String>,
+        color: Option<String>,
+        json: bool,
+    ) -> anyhow::Result<Self> {
+        if name.is_none() && color.is_none() {
+            return Err(anyhow::anyhow!(
+                "At least one of --name or --color must be specified"
+            ));
+        }
+        if let Some(c) = &color {
+            validate_color(c)?;
+        }
+        Ok(Self {
+            key,
+            issue_type_id,
+            name,
+            color,
+            json,
+        })
+    }
+}
+
+#[cfg_attr(test, derive(Debug))]
+pub struct ProjectIssueTypeDeleteArgs {
+    key: String,
+    issue_type_id: u64,
+    substitute_issue_type_id: u64,
+    json: bool,
+}
+
+impl ProjectIssueTypeDeleteArgs {
+    pub fn try_new(
+        key: String,
+        issue_type_id: u64,
+        substitute_issue_type_id: u64,
+        json: bool,
+    ) -> anyhow::Result<Self> {
+        if issue_type_id == substitute_issue_type_id {
+            return Err(anyhow::anyhow!(
+                "--substitute-issue-type-id must differ from --issue-type-id"
+            ));
+        }
+        Ok(Self {
+            key,
+            issue_type_id,
+            substitute_issue_type_id,
+            json,
+        })
+    }
+}
+
 pub fn list(args: &ProjectIssueTypeListArgs) -> Result<()> {
     let client = BacklogClient::from_config()?;
     list_with(args, &client)
@@ -34,6 +118,84 @@ pub fn list_with(args: &ProjectIssueTypeListArgs, api: &dyn BacklogApi) -> Resul
     Ok(())
 }
 
+pub fn add(args: &ProjectIssueTypeAddArgs) -> Result<()> {
+    let client = BacklogClient::from_config()?;
+    add_with(args, &client)
+}
+
+pub fn add_with(args: &ProjectIssueTypeAddArgs, api: &dyn BacklogApi) -> Result<()> {
+    let issue_type = api.add_project_issue_type(&args.key, &args.name, &args.color)?;
+    if args.json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&issue_type).context("Failed to serialize JSON")?
+        );
+    } else {
+        println!("Added: {}", format_issue_type_row(&issue_type));
+    }
+    Ok(())
+}
+
+pub fn update(args: &ProjectIssueTypeUpdateArgs) -> Result<()> {
+    let client = BacklogClient::from_config()?;
+    update_with(args, &client)
+}
+
+pub fn update_with(args: &ProjectIssueTypeUpdateArgs, api: &dyn BacklogApi) -> Result<()> {
+    let mut params: Vec<(String, String)> = Vec::new();
+    if let Some(name) = &args.name {
+        params.push(("name".to_string(), name.clone()));
+    }
+    if let Some(color) = &args.color {
+        params.push(("color".to_string(), color.clone()));
+    }
+    let issue_type = api.update_project_issue_type(&args.key, args.issue_type_id, &params)?;
+    if args.json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&issue_type).context("Failed to serialize JSON")?
+        );
+    } else {
+        println!("Updated: {}", format_issue_type_row(&issue_type));
+    }
+    Ok(())
+}
+
+pub fn delete(args: &ProjectIssueTypeDeleteArgs) -> Result<()> {
+    let client = BacklogClient::from_config()?;
+    delete_with(args, &client)
+}
+
+pub fn delete_with(args: &ProjectIssueTypeDeleteArgs, api: &dyn BacklogApi) -> Result<()> {
+    let issue_type = api.delete_project_issue_type(
+        &args.key,
+        args.issue_type_id,
+        args.substitute_issue_type_id,
+    )?;
+    if args.json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&issue_type).context("Failed to serialize JSON")?
+        );
+    } else {
+        println!("Deleted: {}", format_issue_type_row(&issue_type));
+    }
+    Ok(())
+}
+
+fn validate_color(color: &str) -> anyhow::Result<()> {
+    if color.len() == 7
+        && color.starts_with('#')
+        && color[1..].chars().all(|c| c.is_ascii_hexdigit())
+    {
+        Ok(())
+    } else {
+        Err(anyhow::anyhow!(
+            "Color must be a 6-digit hex code with # prefix (e.g. #e30000)"
+        ))
+    }
+}
+
 fn format_issue_type_row(t: &ProjectIssueType) -> String {
     format!("[{}] {}", t.id, t.name)
 }
@@ -44,14 +206,44 @@ mod tests {
     use anyhow::anyhow;
 
     struct MockApi {
-        issue_types: Option<Vec<ProjectIssueType>>,
+        list: Option<Vec<ProjectIssueType>>,
+        single: Option<ProjectIssueType>,
+    }
+
+    fn mock(list: Option<Vec<ProjectIssueType>>, single: Option<ProjectIssueType>) -> MockApi {
+        MockApi { list, single }
     }
 
     impl crate::api::BacklogApi for MockApi {
         fn get_project_issue_types(&self, _key: &str) -> anyhow::Result<Vec<ProjectIssueType>> {
-            self.issue_types
-                .clone()
-                .ok_or_else(|| anyhow!("no issue types"))
+            self.list.clone().ok_or_else(|| anyhow!("list failed"))
+        }
+
+        fn add_project_issue_type(
+            &self,
+            _key: &str,
+            _name: &str,
+            _color: &str,
+        ) -> anyhow::Result<ProjectIssueType> {
+            self.single.clone().ok_or_else(|| anyhow!("add failed"))
+        }
+
+        fn update_project_issue_type(
+            &self,
+            _key: &str,
+            _issue_type_id: u64,
+            _params: &[(String, String)],
+        ) -> anyhow::Result<ProjectIssueType> {
+            self.single.clone().ok_or_else(|| anyhow!("update failed"))
+        }
+
+        fn delete_project_issue_type(
+            &self,
+            _key: &str,
+            _issue_type_id: u64,
+            _substitute_issue_type_id: u64,
+        ) -> anyhow::Result<ProjectIssueType> {
+            self.single.clone().ok_or_else(|| anyhow!("delete failed"))
         }
     }
 
@@ -76,9 +268,7 @@ mod tests {
 
     #[test]
     fn list_with_text_output_succeeds() {
-        let api = MockApi {
-            issue_types: Some(vec![sample_issue_type()]),
-        };
+        let api = mock(Some(vec![sample_issue_type()]), None);
         assert!(
             list_with(
                 &ProjectIssueTypeListArgs::new("TEST".to_string(), false),
@@ -90,9 +280,7 @@ mod tests {
 
     #[test]
     fn list_with_json_output_succeeds() {
-        let api = MockApi {
-            issue_types: Some(vec![sample_issue_type()]),
-        };
+        let api = mock(Some(vec![sample_issue_type()]), None);
         assert!(
             list_with(
                 &ProjectIssueTypeListArgs::new("TEST".to_string(), true),
@@ -104,12 +292,155 @@ mod tests {
 
     #[test]
     fn list_with_propagates_api_error() {
-        let api = MockApi { issue_types: None };
+        let api = mock(None, None);
         let err = list_with(
             &ProjectIssueTypeListArgs::new("TEST".to_string(), false),
             &api,
         )
         .unwrap_err();
-        assert!(err.to_string().contains("no issue types"));
+        assert!(err.to_string().contains("list failed"));
+    }
+
+    #[test]
+    fn add_try_new_rejects_invalid_color() {
+        let err = ProjectIssueTypeAddArgs::try_new(
+            "TEST".to_string(),
+            "Bug".to_string(),
+            "e30000".to_string(),
+            false,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("hex code"));
+    }
+
+    #[test]
+    fn add_with_text_output_succeeds() {
+        let api = mock(None, Some(sample_issue_type()));
+        let args = ProjectIssueTypeAddArgs::try_new(
+            "TEST".to_string(),
+            "Bug".to_string(),
+            "#e30000".to_string(),
+            false,
+        )
+        .unwrap();
+        assert!(add_with(&args, &api).is_ok());
+    }
+
+    #[test]
+    fn add_with_json_output_succeeds() {
+        let api = mock(None, Some(sample_issue_type()));
+        let args = ProjectIssueTypeAddArgs::try_new(
+            "TEST".to_string(),
+            "Bug".to_string(),
+            "#e30000".to_string(),
+            true,
+        )
+        .unwrap();
+        assert!(add_with(&args, &api).is_ok());
+    }
+
+    #[test]
+    fn add_with_propagates_api_error() {
+        let api = mock(None, None);
+        let args = ProjectIssueTypeAddArgs::try_new(
+            "TEST".to_string(),
+            "Bug".to_string(),
+            "#e30000".to_string(),
+            false,
+        )
+        .unwrap();
+        let err = add_with(&args, &api).unwrap_err();
+        assert!(err.to_string().contains("add failed"));
+    }
+
+    #[test]
+    fn update_try_new_rejects_no_fields() {
+        let err = ProjectIssueTypeUpdateArgs::try_new("TEST".to_string(), 1, None, None, false)
+            .unwrap_err();
+        assert!(err.to_string().contains("At least one"));
+    }
+
+    #[test]
+    fn update_try_new_rejects_invalid_color() {
+        let err = ProjectIssueTypeUpdateArgs::try_new(
+            "TEST".to_string(),
+            1,
+            None,
+            Some("e30000".to_string()),
+            false,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("hex code"));
+    }
+
+    #[test]
+    fn update_with_text_output_succeeds() {
+        let api = mock(None, Some(sample_issue_type()));
+        let args = ProjectIssueTypeUpdateArgs::try_new(
+            "TEST".to_string(),
+            1,
+            Some("Bugfix".to_string()),
+            None,
+            false,
+        )
+        .unwrap();
+        assert!(update_with(&args, &api).is_ok());
+    }
+
+    #[test]
+    fn update_with_json_output_succeeds() {
+        let api = mock(None, Some(sample_issue_type()));
+        let args = ProjectIssueTypeUpdateArgs::try_new(
+            "TEST".to_string(),
+            1,
+            Some("Bugfix".to_string()),
+            None,
+            true,
+        )
+        .unwrap();
+        assert!(update_with(&args, &api).is_ok());
+    }
+
+    #[test]
+    fn update_with_propagates_api_error() {
+        let api = mock(None, None);
+        let args = ProjectIssueTypeUpdateArgs::try_new(
+            "TEST".to_string(),
+            1,
+            Some("Bugfix".to_string()),
+            None,
+            false,
+        )
+        .unwrap();
+        let err = update_with(&args, &api).unwrap_err();
+        assert!(err.to_string().contains("update failed"));
+    }
+
+    #[test]
+    fn delete_try_new_rejects_same_ids() {
+        let err = ProjectIssueTypeDeleteArgs::try_new("TEST".to_string(), 1, 1, false).unwrap_err();
+        assert!(err.to_string().contains("must differ"));
+    }
+
+    #[test]
+    fn delete_with_text_output_succeeds() {
+        let api = mock(None, Some(sample_issue_type()));
+        let args = ProjectIssueTypeDeleteArgs::try_new("TEST".to_string(), 1, 2, false).unwrap();
+        assert!(delete_with(&args, &api).is_ok());
+    }
+
+    #[test]
+    fn delete_with_json_output_succeeds() {
+        let api = mock(None, Some(sample_issue_type()));
+        let args = ProjectIssueTypeDeleteArgs::try_new("TEST".to_string(), 1, 2, true).unwrap();
+        assert!(delete_with(&args, &api).is_ok());
+    }
+
+    #[test]
+    fn delete_with_propagates_api_error() {
+        let api = mock(None, None);
+        let args = ProjectIssueTypeDeleteArgs::try_new("TEST".to_string(), 1, 2, false).unwrap();
+        let err = delete_with(&args, &api).unwrap_err();
+        assert!(err.to_string().contains("delete failed"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,10 @@ use cmd::notification::{NotificationCountArgs, NotificationListArgs, Notificatio
 use cmd::priority::PriorityListArgs;
 use cmd::project::admin::{ProjectAdminAddArgs, ProjectAdminDeleteArgs, ProjectAdminListArgs};
 use cmd::project::category::ProjectCategoryListArgs;
-use cmd::project::issue_type::ProjectIssueTypeListArgs;
+use cmd::project::issue_type::{
+    ProjectIssueTypeAddArgs, ProjectIssueTypeDeleteArgs, ProjectIssueTypeListArgs,
+    ProjectIssueTypeUpdateArgs,
+};
 use cmd::project::status::{
     ProjectStatusAddArgs, ProjectStatusDeleteArgs, ProjectStatusListArgs, ProjectStatusReorderArgs,
     ProjectStatusUpdateArgs,
@@ -541,6 +544,51 @@ enum ProjectIssueTypeCommands {
     List {
         /// Project ID or key
         id_or_key: String,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// Add an issue type to a project
+    Add {
+        /// Project ID or key
+        id_or_key: String,
+        /// Issue type name
+        #[arg(long)]
+        name: String,
+        /// Issue type color (hex code, e.g. #e30000)
+        #[arg(long)]
+        color: String,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// Update a project issue type
+    Update {
+        /// Project ID or key
+        id_or_key: String,
+        /// Issue type ID to update
+        #[arg(long)]
+        issue_type_id: u64,
+        /// New issue type name
+        #[arg(long)]
+        name: Option<String>,
+        /// New issue type color (hex code)
+        #[arg(long)]
+        color: Option<String>,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// Delete a project issue type
+    Delete {
+        /// Project ID or key
+        id_or_key: String,
+        /// Issue type ID to delete
+        #[arg(long)]
+        issue_type_id: u64,
+        /// Issue type ID to substitute for issues with the deleted type
+        #[arg(long)]
+        substitute_issue_type_id: u64,
         /// Output as JSON
         #[arg(long)]
         json: bool,
@@ -1586,6 +1634,38 @@ fn run() -> Result<()> {
                 ProjectIssueTypeCommands::List { id_or_key, json } => {
                     cmd::project::issue_type::list(&ProjectIssueTypeListArgs::new(id_or_key, json))
                 }
+                ProjectIssueTypeCommands::Add {
+                    id_or_key,
+                    name,
+                    color,
+                    json,
+                } => cmd::project::issue_type::add(&ProjectIssueTypeAddArgs::try_new(
+                    id_or_key, name, color, json,
+                )?),
+                ProjectIssueTypeCommands::Update {
+                    id_or_key,
+                    issue_type_id,
+                    name,
+                    color,
+                    json,
+                } => cmd::project::issue_type::update(&ProjectIssueTypeUpdateArgs::try_new(
+                    id_or_key,
+                    issue_type_id,
+                    name,
+                    color,
+                    json,
+                )?),
+                ProjectIssueTypeCommands::Delete {
+                    id_or_key,
+                    issue_type_id,
+                    substitute_issue_type_id,
+                    json,
+                } => cmd::project::issue_type::delete(&ProjectIssueTypeDeleteArgs::try_new(
+                    id_or_key,
+                    issue_type_id,
+                    substitute_issue_type_id,
+                    json,
+                )?),
             },
             ProjectCommands::Category { action } => match action {
                 ProjectCategoryCommands::List { id_or_key, json } => {

--- a/website/docs/commands.md
+++ b/website/docs/commands.md
@@ -419,6 +419,58 @@ Example output:
 [3] Feature Request
 ```
 
+## `bl project issue-type add`
+
+Add an issue type to a project.
+
+```bash
+bl project issue-type add <id-or-key> --name <name> --color <color>
+bl project issue-type add <id-or-key> --name <name> --color <color> --json
+```
+
+`--color` must be a 6-digit hex code with a `#` prefix (e.g. `#e30000`).
+
+Example output:
+
+```text
+Added: [1] Bug
+```
+
+## `bl project issue-type update`
+
+Update a project issue type.
+
+```bash
+bl project issue-type update <id-or-key> --issue-type-id <id> --name <name>
+bl project issue-type update <id-or-key> --issue-type-id <id> --color <color>
+bl project issue-type update <id-or-key> --issue-type-id <id> --name <name> --color <color> --json
+```
+
+At least one of `--name` or `--color` must be specified. `--color` must be a valid hex code.
+
+Example output:
+
+```text
+Updated: [1] Bug
+```
+
+## `bl project issue-type delete`
+
+Delete a project issue type. Issues using the deleted type are moved to the substitute type.
+
+```bash
+bl project issue-type delete <id-or-key> --issue-type-id <id> --substitute-issue-type-id <id>
+bl project issue-type delete <id-or-key> --issue-type-id <id> --substitute-issue-type-id <id> --json
+```
+
+`--substitute-issue-type-id` must differ from `--issue-type-id`.
+
+Example output:
+
+```text
+Deleted: [1] Bug
+```
+
 ## `bl project category list`
 
 List categories defined for a specific project.
@@ -1327,9 +1379,9 @@ The table below maps Backlog API v2 endpoints to `bl` commands.
 | `bl project status delete <id-or-key> --status-id <id>` | `DELETE /api/v2/projects/{projectIdOrKey}/statuses/{id}` | ✅ Implemented |
 | `bl project status reorder <id-or-key>` | `PATCH /api/v2/projects/{projectIdOrKey}/statuses/updateDisplayOrder` | ✅ Implemented |
 | `bl project issue-type list <id-or-key>` | `GET /api/v2/projects/{projectIdOrKey}/issueTypes` | ✅ Implemented |
-| `bl project issue-type add <id-or-key>` | `POST /api/v2/projects/{projectIdOrKey}/issueTypes` | Planned |
-| `bl project issue-type update <id-or-key> <id>` | `PATCH /api/v2/projects/{projectIdOrKey}/issueTypes/{id}` | Planned |
-| `bl project issue-type delete <id-or-key> <id>` | `DELETE /api/v2/projects/{projectIdOrKey}/issueTypes/{id}` | Planned |
+| `bl project issue-type add <id-or-key>` | `POST /api/v2/projects/{projectIdOrKey}/issueTypes` | ✅ Implemented |
+| `bl project issue-type update <id-or-key> --issue-type-id <id>` | `PATCH /api/v2/projects/{projectIdOrKey}/issueTypes/{id}` | ✅ Implemented |
+| `bl project issue-type delete <id-or-key> --issue-type-id <id>` | `DELETE /api/v2/projects/{projectIdOrKey}/issueTypes/{id}` | ✅ Implemented |
 | `bl project category list <id-or-key>` | `GET /api/v2/projects/{projectIdOrKey}/categories` | ✅ Implemented |
 | `bl project category add <id-or-key>` | `POST /api/v2/projects/{projectIdOrKey}/categories` | Planned |
 | `bl project category update <id-or-key> <id>` | `PATCH /api/v2/projects/{projectIdOrKey}/categories/{id}` | Planned |

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/commands.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/commands.md
@@ -419,6 +419,58 @@ bl project issue-type list <id-or-key> --json
 [3] Feature Request
 ```
 
+## `bl project issue-type add`
+
+プロジェクトに課題種別を追加します。
+
+```bash
+bl project issue-type add <id-or-key> --name <name> --color <color>
+bl project issue-type add <id-or-key> --name <name> --color <color> --json
+```
+
+`--color` は `#` プレフィックス付きの6桁 hex コード（例: `#e30000`）を指定してください。
+
+出力例:
+
+```text
+Added: [1] Bug
+```
+
+## `bl project issue-type update`
+
+プロジェクトの課題種別を更新します。
+
+```bash
+bl project issue-type update <id-or-key> --issue-type-id <id> --name <name>
+bl project issue-type update <id-or-key> --issue-type-id <id> --color <color>
+bl project issue-type update <id-or-key> --issue-type-id <id> --name <name> --color <color> --json
+```
+
+`--name` または `--color` の少なくとも一方を指定してください。`--color` は有効な hex コードである必要があります。
+
+出力例:
+
+```text
+Updated: [1] Bug
+```
+
+## `bl project issue-type delete`
+
+プロジェクトの課題種別を削除します。削除された種別の課題は代替種別に移動されます。
+
+```bash
+bl project issue-type delete <id-or-key> --issue-type-id <id> --substitute-issue-type-id <id>
+bl project issue-type delete <id-or-key> --issue-type-id <id> --substitute-issue-type-id <id> --json
+```
+
+`--substitute-issue-type-id` は `--issue-type-id` と異なる値を指定してください。
+
+出力例:
+
+```text
+Deleted: [1] Bug
+```
+
 ## `bl project category list`
 
 特定のプロジェクトのカテゴリーを一覧表示します。
@@ -1331,9 +1383,9 @@ Backlog API v2 エンドポイントと `bl` コマンドの対応表です。
 | `bl project status delete <id-or-key> --status-id <id>` | `DELETE /api/v2/projects/{projectIdOrKey}/statuses/{id}` | ✅ 実装済み |
 | `bl project status reorder <id-or-key>` | `PATCH /api/v2/projects/{projectIdOrKey}/statuses/updateDisplayOrder` | ✅ 実装済み |
 | `bl project issue-type list <id-or-key>` | `GET /api/v2/projects/{projectIdOrKey}/issueTypes` | ✅ 実装済み |
-| `bl project issue-type add <id-or-key>` | `POST /api/v2/projects/{projectIdOrKey}/issueTypes` | 計画中 |
-| `bl project issue-type update <id-or-key> <id>` | `PATCH /api/v2/projects/{projectIdOrKey}/issueTypes/{id}` | 計画中 |
-| `bl project issue-type delete <id-or-key> <id>` | `DELETE /api/v2/projects/{projectIdOrKey}/issueTypes/{id}` | 計画中 |
+| `bl project issue-type add <id-or-key>` | `POST /api/v2/projects/{projectIdOrKey}/issueTypes` | ✅ 実装済み |
+| `bl project issue-type update <id-or-key> --issue-type-id <id>` | `PATCH /api/v2/projects/{projectIdOrKey}/issueTypes/{id}` | ✅ 実装済み |
+| `bl project issue-type delete <id-or-key> --issue-type-id <id>` | `DELETE /api/v2/projects/{projectIdOrKey}/issueTypes/{id}` | ✅ 実装済み |
 | `bl project category list <id-or-key>` | `GET /api/v2/projects/{projectIdOrKey}/categories` | ✅ 実装済み |
 | `bl project category add <id-or-key>` | `POST /api/v2/projects/{projectIdOrKey}/categories` | 計画中 |
 | `bl project category update <id-or-key> <id>` | `PATCH /api/v2/projects/{projectIdOrKey}/categories/{id}` | 計画中 |


### PR DESCRIPTION
## Checklist

- [x] Target branch is `main`
- [ ] Status checks are passing
- [x] Documentation updated if user-visible behavior changed (`website/docs/`, `website/i18n/ja/`, `README.md`)

## Summary

- Add `bl project issue-type add` — `POST /api/v2/projects/{projectIdOrKey}/issueTypes`
- Add `bl project issue-type update` — `PATCH /api/v2/projects/{projectIdOrKey}/issueTypes/{id}`
- Add `bl project issue-type delete` — `DELETE /api/v2/projects/{projectIdOrKey}/issueTypes/{id}`

## Reason for change

Implements issue #39.

## Changes

- `src/api/project.rs` — `add_project_issue_type`, `update_project_issue_type`, `delete_project_issue_type`
- `src/api/mod.rs` — trait declarations and `BacklogClient` delegation
- `src/cmd/project/issue_type.rs` — `add`/`add_with`, `update`/`update_with`, `delete`/`delete_with` with Args structs, validation (`validate_color`, same-ID check), and tests
- `src/main.rs` — clap wiring for the three new subcommands
- `website/docs/commands.md` / `website/i18n/ja/…/commands.md` — command docs and coverage table

## Notes

- Color validation (`#RRGGBB`) and same-ID rejection (`--issue-type-id` ≠ `--substitute-issue-type-id`) follow the same `try_new` pattern established for `bl project status`.

Closes #39