### PR TITLE
feat: bl rate-limit

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -13,6 +13,7 @@ pub mod licence;
 pub mod notification;
 pub mod priority;
 pub mod project;
+pub mod rate_limit;
 pub mod resolution;
 pub mod space;
 pub mod space_notification;
@@ -34,6 +35,7 @@ use project::{
     Project, ProjectCategory, ProjectCustomField, ProjectDiskUsage, ProjectIssueType,
     ProjectStatus, ProjectUser, ProjectVersion,
 };
+use rate_limit::RateLimit;
 use resolution::Resolution;
 use space::Space;
 use space_notification::SpaceNotification;
@@ -59,6 +61,9 @@ use wiki::{Wiki, WikiAttachment, WikiHistory, WikiListItem};
 ///    `unimplemented!()` fires automatically if an untested method is called.
 pub trait BacklogApi {
     fn get_space(&self) -> Result<Space> {
+        unimplemented!()
+    }
+    fn get_rate_limit(&self) -> Result<RateLimit> {
         unimplemented!()
     }
     fn get_myself(&self) -> Result<User> {
@@ -488,6 +493,10 @@ pub trait BacklogApi {
 impl BacklogApi for BacklogClient {
     fn get_space(&self) -> Result<Space> {
         self.get_space()
+    }
+
+    fn get_rate_limit(&self) -> Result<RateLimit> {
+        self.get_rate_limit()
     }
 
     fn get_myself(&self) -> Result<User> {

--- a/src/api/rate_limit.rs
+++ b/src/api/rate_limit.rs
@@ -1,0 +1,77 @@
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+use super::BacklogClient;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RateLimitInfo {
+    pub limit: u64,
+    pub remaining: u64,
+    pub reset: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RateLimit {
+    pub rate_limit: RateLimitInfo,
+}
+
+impl BacklogClient {
+    pub fn get_rate_limit(&self) -> Result<RateLimit> {
+        let value = self.get("/rateLimit")?;
+        serde_json::from_value(value.clone()).map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to deserialize rate limit response: {}\nRaw JSON:\n{}",
+                e,
+                serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string())
+            )
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use httpmock::prelude::*;
+    use serde_json::json;
+
+    fn rate_limit_json() -> serde_json::Value {
+        json!({
+            "rateLimit": {
+                "limit": 600,
+                "remaining": 599,
+                "reset": 1698230400
+            }
+        })
+    }
+
+    #[test]
+    fn get_rate_limit_returns_parsed_struct() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(GET).path("/rateLimit");
+            then.status(200).json_body(rate_limit_json());
+        });
+
+        let client = BacklogClient::new_with(&server.base_url(), "test-key").unwrap();
+        let rl = client.get_rate_limit().unwrap();
+        assert_eq!(rl.rate_limit.limit, 600);
+        assert_eq!(rl.rate_limit.remaining, 599);
+        assert_eq!(rl.rate_limit.reset, 1698230400);
+    }
+
+    #[test]
+    fn get_rate_limit_returns_error_on_api_failure() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(GET).path("/rateLimit");
+            then.status(401)
+                .json_body(json!({"errors": [{"message": "Authentication failure"}]}));
+        });
+
+        let client = BacklogClient::new_with(&server.base_url(), "test-key").unwrap();
+        let err = client.get_rate_limit().unwrap_err();
+        assert!(err.to_string().contains("Authentication failure"));
+    }
+}

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -4,6 +4,7 @@ pub mod issue;
 pub mod notification;
 pub mod priority;
 pub mod project;
+pub mod rate_limit;
 pub mod resolution;
 pub mod space;
 pub mod team;

--- a/src/cmd/rate_limit.rs
+++ b/src/cmd/rate_limit.rs
@@ -1,0 +1,99 @@
+use anstream::println;
+use anyhow::{Context, Result};
+
+use crate::api::{BacklogApi, BacklogClient, rate_limit::RateLimit};
+
+pub struct RateLimitArgs {
+    json: bool,
+}
+
+impl RateLimitArgs {
+    pub fn new(json: bool) -> Self {
+        Self { json }
+    }
+}
+
+pub fn show(args: &RateLimitArgs) -> Result<()> {
+    let client = BacklogClient::from_config()?;
+    show_with(args, &client)
+}
+
+pub fn show_with(args: &RateLimitArgs, api: &dyn BacklogApi) -> Result<()> {
+    let rl = api.get_rate_limit()?;
+    if args.json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&rl).context("Failed to serialize JSON")?
+        );
+    } else {
+        println!("{}", format_rate_limit_text(&rl));
+    }
+    Ok(())
+}
+
+fn format_rate_limit_text(rl: &RateLimit) -> String {
+    format!(
+        "Limit:     {}\nRemaining: {}\nReset:     {}",
+        rl.rate_limit.limit, rl.rate_limit.remaining, rl.rate_limit.reset,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::rate_limit::RateLimitInfo;
+    use anyhow::anyhow;
+
+    struct MockApi {
+        rate_limit: Option<RateLimit>,
+    }
+
+    impl crate::api::BacklogApi for MockApi {
+        fn get_rate_limit(&self) -> anyhow::Result<RateLimit> {
+            self.rate_limit
+                .clone()
+                .ok_or_else(|| anyhow!("no rate limit"))
+        }
+    }
+
+    fn sample_rate_limit() -> RateLimit {
+        RateLimit {
+            rate_limit: RateLimitInfo {
+                limit: 600,
+                remaining: 599,
+                reset: 1698230400,
+            },
+        }
+    }
+
+    #[test]
+    fn show_with_text_output_succeeds() {
+        let api = MockApi {
+            rate_limit: Some(sample_rate_limit()),
+        };
+        assert!(show_with(&RateLimitArgs::new(false), &api).is_ok());
+    }
+
+    #[test]
+    fn show_with_json_output_succeeds() {
+        let api = MockApi {
+            rate_limit: Some(sample_rate_limit()),
+        };
+        assert!(show_with(&RateLimitArgs::new(true), &api).is_ok());
+    }
+
+    #[test]
+    fn show_with_propagates_api_error() {
+        let api = MockApi { rate_limit: None };
+        let err = show_with(&RateLimitArgs::new(false), &api).unwrap_err();
+        assert!(err.to_string().contains("no rate limit"));
+    }
+
+    #[test]
+    fn format_rate_limit_text_contains_all_fields() {
+        let text = format_rate_limit_text(&sample_rate_limit());
+        assert!(text.contains("600"));
+        assert!(text.contains("599"));
+        assert!(text.contains("1698230400"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,7 @@ use cmd::project::{
     ProjectActivitiesArgs, ProjectCreateArgs, ProjectDeleteArgs, ProjectDiskUsageArgs,
     ProjectListArgs, ProjectShowArgs, ProjectUpdateArgs,
 };
+use cmd::rate_limit::RateLimitArgs;
 use cmd::resolution::ResolutionListArgs;
 use cmd::space::{
     SpaceActivitiesArgs, SpaceDiskUsageArgs, SpaceLicenceArgs, SpaceNotificationArgs,
@@ -154,6 +155,12 @@ enum Commands {
     Resolution {
         #[command(subcommand)]
         action: ResolutionCommands,
+    },
+    /// Show API rate limit status
+    RateLimit {
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
     },
 }
 
@@ -2509,6 +2516,7 @@ fn run() -> Result<()> {
                 cmd::resolution::list(&ResolutionListArgs::new(json))
             }
         },
+        Commands::RateLimit { json } => cmd::rate_limit::show(&RateLimitArgs::new(json)),
         Commands::Space { action, json } => match action {
             None => cmd::space::show(&SpaceShowArgs::new(json)),
             Some(SpaceCommands::Activities {

--- a/website/docs/commands.md
+++ b/website/docs/commands.md
@@ -1571,6 +1571,23 @@ Example output:
 [4] Cannot Reproduce
 ```
 
+## `bl rate-limit`
+
+Show the current API rate limit status.
+
+```bash
+bl rate-limit
+bl rate-limit --json
+```
+
+Example output:
+
+```text
+Limit:     600
+Remaining: 599
+Reset:     1698230400
+```
+
 ## Command coverage
 
 The table below maps Backlog API v2 endpoints to `bl` commands.
@@ -1798,4 +1815,4 @@ The table below maps Backlog API v2 endpoints to `bl` commands.
 
 | Command | API endpoint | Status |
 | --- | --- | --- |
-| `bl rate-limit` | `GET /api/v2/rateLimit` | Planned |
+| `bl rate-limit` | `GET /api/v2/rateLimit` | ✅ Implemented |

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/commands.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/commands.md
@@ -1575,6 +1575,23 @@ bl resolution list [--json]
 [4] 再現しない
 ```
 
+## `bl rate-limit`
+
+API レート制限の現在の状況を表示します。
+
+```bash
+bl rate-limit
+bl rate-limit --json
+```
+
+出力例:
+
+```text
+Limit:     600
+Remaining: 599
+Reset:     1698230400
+```
+
 ## コマンドカバレッジ
 
 Backlog API v2 エンドポイントと `bl` コマンドの対応表です。
@@ -1802,4 +1819,4 @@ Backlog API v2 エンドポイントと `bl` コマンドの対応表です。
 
 | コマンド | API エンドポイント | 状態 |
 | --- | --- | --- |
-| `bl rate-limit` | `GET /api/v2/rateLimit` | 計画中 |
+| `bl rate-limit` | `GET /api/v2/rateLimit` | ✅ 実装済み |


### PR DESCRIPTION
## Checklist

- [x] Target branch is `main`
- [x] Status checks are passing
- [x] Documentation updated if user-visible behavior changed (`website/docs/`, `website/i18n/ja/`, `README.md`)

## Summary

- Add `bl rate-limit` command to show current API rate limit status
- Implement `GET /api/v2/rateLimit` in `BacklogClient` and `BacklogApi` trait

## Reason for change

Implements #57.

## Changes

- `src/api/rate_limit.rs`: `RateLimit` / `RateLimitInfo` structs + `get_rate_limit` method with tests
- `src/api/mod.rs`: Declare trait method and delegate to `BacklogClient`
- `src/cmd/rate_limit.rs`: `show` / `show_with` with tests
- `src/cmd/mod.rs`: Add `pub mod rate_limit`
- `src/main.rs`: Wire up `Commands::RateLimit` via clap
- `website/docs/commands.md`, `website/i18n/ja/.../commands.md`: Add docs and mark as implemented

## Notes

Closes #57