### PR TITLE
refactor: rename format_team_row to format_project_team_row in cmd/project/team.rs

### DIFF
--- a/src/cmd/project/team.rs
+++ b/src/cmd/project/team.rs
@@ -28,7 +28,7 @@ pub fn list_with(args: &ProjectTeamListArgs, api: &dyn BacklogApi) -> Result<()>
         );
     } else {
         for t in &teams {
-            println!("{}", format_team_row(t));
+            println!("{}", format_project_team_row(t));
         }
     }
     Ok(())
@@ -59,7 +59,7 @@ pub fn add_with(args: &ProjectTeamAddArgs, api: &dyn BacklogApi) -> Result<()> {
             serde_json::to_string_pretty(&team).context("Failed to serialize JSON")?
         );
     } else {
-        println!("Added: {}", format_team_row(&team));
+        println!("Added: {}", format_project_team_row(&team));
     }
     Ok(())
 }
@@ -89,12 +89,12 @@ pub fn delete_with(args: &ProjectTeamDeleteArgs, api: &dyn BacklogApi) -> Result
             serde_json::to_string_pretty(&team).context("Failed to serialize JSON")?
         );
     } else {
-        println!("Deleted: {}", format_team_row(&team));
+        println!("Deleted: {}", format_project_team_row(&team));
     }
     Ok(())
 }
 
-fn format_team_row(t: &Team) -> String {
+fn format_project_team_row(t: &Team) -> String {
     format!("[{}] {}", t.id, t.name)
 }
 
@@ -136,8 +136,8 @@ mod tests {
     }
 
     #[test]
-    fn format_team_row_shows_id_and_name() {
-        let text = format_team_row(&sample_team());
+    fn format_project_team_row_shows_id_and_name() {
+        let text = format_project_team_row(&sample_team());
         assert!(text.contains("[1]"));
         assert!(text.contains("dev-team"));
     }


### PR DESCRIPTION
## Checklist

- [x] Target branch is `main`
- [x] Status checks are passing
- [ ] Documentation updated if user-visible behavior changed (`website/docs/`, `website/i18n/ja/`, `README.md`)

## Summary

- Rename `format_team_row` → `format_project_team_row` in `src/cmd/project/team.rs`

## Reason for change

Two functions named `format_team_row` existed with different output formats:
- `src/cmd/team/mod.rs`: `"[id] name (N members)"` — includes member count
- `src/cmd/project/team.rs`: `"[id] name"` — omits member count

The identical name was misleading. No behavior change.

## Changes

- Renamed function and updated all call sites within `src/cmd/project/team.rs`

Closes #110