### PR TITLE
ci: add macOS and Windows cargo check to PR checks

### DIFF
--- a/.github/workflows/check-rust.yml
+++ b/.github/workflows/check-rust.yml
@@ -58,6 +58,24 @@ jobs:
       - name: Check
         run: mise run rs-check
 
+  check-macos:
+    runs-on: macos-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Install Rust
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+        with:
+          rustflags: ""
+
+      - name: Check
+        run: cargo check --locked
+
   check-windows:
     runs-on: windows-latest
     permissions:
@@ -70,6 +88,8 @@ jobs:
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+        with:
+          rustflags: ""
 
       - name: Check
         run: cargo check --locked


### PR DESCRIPTION
## Checklist

- [x] Target branch is `main`
- [ ] Status checks are passing
- [x] Documentation updated if user-visible behavior changed (`website/docs/`, `website/i18n/ja/`, `README.md`)

## Summary

Add `cargo check --locked` jobs for macOS and Windows to the `check-rust` workflow so that cross-platform compile errors are caught on PR before release.

## Reason for change

Recent releases failed on macOS and Windows due to platform-specific compile errors that were not caught by the Linux-only PR checks. Lightweight `cargo check` on each platform gives early signal without the cost of a full cross-compile matrix.

## Changes

- Added `check-macos` job: `macos-latest`, `cargo check --locked`
- Added `rustflags: ""` to `check-windows` Install Rust step (suppresses warnings-as-errors from the toolchain action default)

## Notes

Both jobs run only `cargo check` (not `clippy` or tests) to keep CI fast.