### PR TITLE
ci: add manual workflow to diagnose Windows smoke test failure

### DIFF
--- a/.github/workflows/smoke-test-windows.yml
+++ b/.github/workflows/smoke-test-windows.yml
@@ -1,0 +1,65 @@
+name: Smoke Test Windows
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+permissions:
+  contents: read
+
+jobs:
+  smoke-test:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Install Rust
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+        with:
+          target: x86_64-pc-windows-msvc
+          rustflags: ""
+          cache: false
+
+      - name: Disable Windows Defender real-time monitoring
+        shell: pwsh
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
+
+      - name: Verify Defender status
+        shell: pwsh
+        run: Get-MpPreference | Select-Object DisableRealtimeMonitoring, ExclusionPath
+
+      - name: Build release binary
+        env:
+          TARGET: x86_64-pc-windows-msvc
+        run: cargo build --release --locked --target $env:TARGET
+
+      - name: List release dir
+        shell: pwsh
+        env:
+          TARGET: x86_64-pc-windows-msvc
+        run: Get-ChildItem ./target/$env:TARGET/release/ | Select-Object Name, Length
+
+      - name: Check Defender threat detections
+        shell: pwsh
+        run: |
+          $threats = Get-MpThreatDetection
+          if ($threats) {
+            $threats | Select-Object ActionSuccess, DetectionSourceTypeID, DomainUser, InitialDetectionTime, Resources, ThreatID
+          } else {
+            Write-Host "No threat detections."
+          }
+
+      - name: Smoke test
+        shell: pwsh
+        env:
+          TARGET: x86_64-pc-windows-msvc
+        run: ./target/$env:TARGET/release/bl.exe --help


### PR DESCRIPTION
## Checklist

- [x] Target branch is `main`
- [x] Status checks are passing
- [x] Documentation updated if user-visible behavior changed (`website/docs/`, `website/i18n/ja/`, `README.md`)

## Summary

Add a `workflow_dispatch` workflow to manually test the Windows release build and smoke test in isolation, before running a full release.

## Reason for change

Recent releases have repeatedly failed on the Windows smoke test. This workflow lets us verify the fix (`Set-MpPreference -DisableRealtimeMonitoring $true`) without pushing a release tag.

## Changes

- Added `.github/workflows/smoke-test-windows.yml` with:
  - Disable Defender real-time monitoring
  - Verify Defender status (`DisableRealtimeMonitoring`, `ExclusionPath`)
  - Build `x86_64-pc-windows-msvc` release binary
  - List release directory contents
  - Check Defender threat detections after build
  - Run smoke test (`bl.exe --help`)

## Notes

Diagnostic-only workflow, not triggered on push/PR.